### PR TITLE
Add configs for packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Build-time setuptools-scm generated version module
+/src/sphinxcontrib/towncrier/_scm_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = [
+  # Essentials
+  "setuptools>=40.6.0",
+  "wheel",
+
+  # Plugins
+  "setuptools_scm[toml] >= 3.5",  # version is required for "no-local-version" scheme + toml extra is needed for supporting config in this file
+  "setuptools_scm_git_archive >= 1.1",
+]
+build-backend = "setuptools.build_meta"
+
+# ATTENTION: the following section must be kept last in
+# `pyproject.toml` because the CI appends one line in
+# the end when publishing non-tagged versions.
+[tool.setuptools_scm]
+write_to = "src/sphinxcontrib/towncrier/_scm_version.py"
+# ATTENTION: DO NOT ADD ANYTHING AFTER THIS SECTION ^

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,56 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+name = sphinxcontrib-towncrier
+url = https://github.com/sphinx-contrib/towncrier
+project_urls =
+    GitHub: repo = https://github.com/sphinx-contrib/towncrier
+    GitHub: issues = https://github.com/sphinx-contrib/towncrier/issues
+description = An RST directive for injecting a Towncrier-generated changelog draft containing fragments for the unreleased (next) project version
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = Sviatoslav Sydorenko
+author_email = wk+pypi/sphinxcontrib-towncrier@sydorenko.org.ua
+maintainer = Oleksiy Vasylyshyn
+maintainer_email = slsh1o-git@protonmail.com
+license = BSD 3-Clause License
+license_files =
+    LICENSE
+classifiers =
+    Development Status :: 3 - Alpha
+
+    Framework :: Sphinx
+    Framework :: Sphinx :: Extension
+
+    Intended Audience :: Developers
+
+    License :: OSI Approved :: BSD License
+
+    Operating System :: OS Independent
+
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+    Topic :: Software Development :: Documentation
+
+    Topic :: Documentation :: Sphinx
+    Topic :: System :: Software Distribution
+    Topic :: Utilities
+
+[options]
+include_package_data = True
+install_requires =
+    sphinx
+    setuptools_scm
+    towncrier
+package_dir =
+    = src
+packages = find_namespace:
+python_requires = >=3.6
+zip_safe = True
+
+[options.packages.find]
+where = src


### PR DESCRIPTION
It's what I have for now.
I haven't specify any info about python versions and Operating System. Also I put into `pyproject.toml` only essential configs. I'm sure I should add more configs, please let me know which one.

And actually I wasn't able to run `python -c 'from sphinxcontrib.towncrier import TowncrierDraftEntriesDirective, setup'` even though all installation/test steps from #4 passed without issues and nothing explodes.
Running `pip freeze` shows `sphinxcontrib-towncrier` as installed but I receive `ModuleNotFoundError: No module named 'sphinxcontrib'` error.  I'm not sure what's wrong.